### PR TITLE
Take into account all branches and add --verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ To list modules for all platforms, simply run:
 ci-triage
 ```
 
+To get verbose output that lists all branches and failing jobs individually, run with the `--verbose` option:
+```shell
+ci-triage --verbose
+```
+
 To specify specific platforms, use the -p option and list platforms as arguments separated by commas:
 ```shell
 ci-triage -p linux,windows,netdev

--- a/lib/citriage.rb
+++ b/lib/citriage.rb
@@ -98,7 +98,7 @@ module Citriage
 
     def run
       program :name, 'ci-triage'
-      program :version, Citriage::VERSION
+      program :version, VERSION
       program :description, 'CLI tool for Modules CI Triage'
 
       command :all do |c|
@@ -106,7 +106,7 @@ module Citriage
         c.description = 'Lists all modules at the top level.'
         c.option '--platform STRING', String, 'Platform(s) to display.'
         c.action do |args, opts|
-          if opts.platform.size > 0
+          if !opts.platform.nil?
             platforms = opts.platform.split(',')
           else
             platforms = ["windows", "linux", "cross-platform", "cloud", "netdev"]

--- a/lib/citriage.rb
+++ b/lib/citriage.rb
@@ -85,8 +85,6 @@ module Citriage
               mod_status = false
               failed_job = job['url']
               break
-            else
-              mod_status = true
             end
           end
         end

--- a/lib/citriage.rb
+++ b/lib/citriage.rb
@@ -18,19 +18,22 @@ module Citriage
       "#{url}/api/json"
     end
 
-    def get_json url
+    def get_response url
       _url = api_url url
 
-      response = Curl.get(_url) do |curl|
+      Curl.get(_url) do |curl|
         curl.on_failure { |failure| puts "cURL failed for #{failure.url}" }
       end
+    end
+
+    def get_json url, response
+      _url = api_url url
 
       begin
         JSON.parse(response.body_str)
       rescue JSON::ParserError
         puts "There was a problem parsing the JSON for #{_url}".color(:red)
       end
-
     end
 
     def platform_dir platform
@@ -51,8 +54,10 @@ module Citriage
 
     def assemble_module_list platform
       _platform = platform_dir platform
+      url = "#{@base_url}#{_platform}"
 
-      list_json = get_json "#{@base_url}#{_platform}"
+      response = get_response url
+      list_json = get_json url, response
       module_list = Array.new
 
       list_json['views'].each do |_module|
@@ -65,7 +70,7 @@ module Citriage
     def generate_url platform, module_name, branch_name
       _platform = "#{platform_dir platform}/view"
       _module_name = "/#{module_name}/view"
-      branch_name = "/#{module_name}%20-%20#{branch_name}/"
+      branch_name = "/#{module_name}%20-%20#{branch_name}"
 
       @base_url + _platform + _module_name + branch_name
     end
@@ -74,21 +79,23 @@ module Citriage
       mod_status = true
       failed_job = String.new
       begin
-        json['jobs'].each do |job|
-          if job['color'] == 'red'
-            mod_status = false
-            failed_job = job['url']
-            break
-          else
-            mod_status = true
+        json.each do |name, branch|
+          branch['jobs'].each do |job|
+            if job['color'] == 'red'
+              mod_status = false
+              failed_job = job['url']
+              break
+            else
+              mod_status = true
+            end
           end
         end
         if mod_status
           print "\u25CF ".color(:green)
-          puts json['name'].split(" ")[0]
+          puts json[:master]['name'].split(" ")[0]
         else
           print "\u25CF ".color(:red)
-          print json['name'].split(" ")[0]
+          print json[:master]['name'].split(" ")[0]
           puts " FAILURE: #{failed_job}".color(:red)
         end
       rescue NoMethodError
@@ -118,8 +125,31 @@ module Citriage
 
             modules.each do |mod|
               unless mod == "ad hoc"
-                json = get_json(generate_url platform,mod,"master")
-                list_jobs json
+                job_list = {}
+
+                master_url = generate_url(platform, mod, "master")
+                stable_url = generate_url(platform, mod, "stable")
+                release_url = generate_url(platform, mod, "release")
+
+                master_response = get_response master_url
+
+                # We know we'll always get data back for master
+                job_list[:master] = get_json master_url, master_response
+
+                # Check for 'stable' and 'release' pipelines
+                # Not all pipelines will have them but most will have one or the other
+                stable_response = get_response stable_url
+                if !stable_response.body_str.include? "Error 404"
+                  job_list[:stable] = get_json stable_url, stable_response
+                end
+
+                release_response = get_response release_url
+                if !release_response.body_str.include? "Error 404"
+                  job_list[:release] = get_json release_url, release_response
+                end
+
+                list_jobs job_list
+
               end
             end
           end


### PR DESCRIPTION
This pull request fixes a minor bug and add two features to the
ci-triage gem. The features are:
1. **Account for the status of all branches.** Up until now the gem
   only considered the status of the master branch. This meant that if
   master was green while other branches were red we would get a
   false positive. Now the ci-triage command will take into account all 
   branches (usually master and then either stable or release).
2.  **Add verbose output.** Since we're now collecting data about
   every branch, take advantage of this and add a verbose output option.
   This prints the status of each branch individually as well as a comprehensive
   list of URLs for failing jobs. You can take advantage of it by using the
   '--verbose' flag. Here is an example of regular vs verbose output:

```
$ be ci-triage -p windows                                                                        
WINDOWS
● acl FAILURE: https://jenkins-modules.puppetlabs.com/job/forge-windows_puppetlabs-acl_intn-sys_smoke-stable/
● chocolatey
● dsc
● powershell
● reboot
● registry
● sqlserver
● wsus_client

$ be ci-triage --verbose -p windows                                                              
WINDOWS
[acl]
● master
    FAILURE: https://jenkins-modules.puppetlabs.com/job/forge-windows_puppetlabs-acl_intn-sys_smoke-master/
● stable
    FAILURE: https://jenkins-modules.puppetlabs.com/job/forge-windows_puppetlabs-acl_intn-sys_smoke-stable/
[chocolatey]
● master
[dsc]
● master
[powershell]
● master
● stable
[reboot]
● master
● stable
[registry]
● master
● stable
[sqlserver]
● master
● stable
[wsus_client]
● master
● stable
```
